### PR TITLE
new ioctl USBTMC_IOCTL_CTRL_REQUEST

### DIFF
--- a/tmc.h
+++ b/tmc.h
@@ -15,6 +15,8 @@
 #ifndef __LINUX_USB_TMC_H
 #define __LINUX_USB_TMC_H
 
+#include <linux/usb/ch9.h>
+
 /* USB TMC status values */
 #define USBTMC_STATUS_SUCCESS				0x01
 #define USBTMC_STATUS_PENDING				0x02
@@ -37,6 +39,12 @@
 #define USBTMC488_REQUEST_GOTO_LOCAL			161
 #define USBTMC488_REQUEST_LOCAL_LOCKOUT			162
 
+struct usbtmc_ctrlrequest
+{
+	struct usb_ctrlrequest req;
+	void* data;
+} __attribute__ ((packed));
+
 /* Request values for USBTMC driver's ioctl entry point */
 #define USBTMC_IOC_NR			91
 #define USBTMC_IOCTL_INDICATOR_PULSE	_IO(USBTMC_IOC_NR, 1)
@@ -45,6 +53,7 @@
 #define USBTMC_IOCTL_ABORT_BULK_IN	_IO(USBTMC_IOC_NR, 4)
 #define USBTMC_IOCTL_CLEAR_OUT_HALT	_IO(USBTMC_IOC_NR, 6)
 #define USBTMC_IOCTL_CLEAR_IN_HALT	_IO(USBTMC_IOC_NR, 7)
+#define USBTMC_IOCTL_CTRL_REQUEST	_IOWR(USBTMC_IOC_NR, 8, struct usbtmc_ctrlrequest)
 #define USBTMC488_IOCTL_GET_CAPS	_IOR(USBTMC_IOC_NR, 17, unsigned char)
 #define USBTMC488_IOCTL_READ_STB	_IOR(USBTMC_IOC_NR, 18, unsigned char)
 #define USBTMC488_IOCTL_REN_CONTROL	_IOW(USBTMC_IOC_NR, 19, unsigned char)


### PR DESCRIPTION
Hi Dave,
I'm a newbie in using github and I hope this is the right way to add contributions to the experimental usbtmc driver.
I added a more generic ioctl USBTMC_IOCTL_CTRL_REQUEST which allows to get/set the configuration, vendor strings, etc. over the control pipe. This ioctl is also needed for the VISA functions viUsbControlIn and viUsbControlOut which allows to test T&M instruments (Halt/Stall/abort/enable endpoints).
**This branch is not well tested, yet, and is not pre-decided with other IVI members.** 

-Guido